### PR TITLE
Changed numberWithInt: to numberWithInteger: to silence a warning.

### DIFF
--- a/NSObject+Properties.m
+++ b/NSObject+Properties.m
@@ -96,7 +96,7 @@
             case 'i':   // int
                 [invocation invoke];
                 [invocation getReturnValue:&intValue];
-                [coder encodeObject:[NSNumber numberWithInt:intValue] forKey:key];
+                [coder encodeObject:[NSNumber numberWithInteger:intValue] forKey:key];
                 break;
             case 'L':   // unsigned long
                 [invocation invoke];


### PR DESCRIPTION
NSInteger can be either typedef long or int depending on the platform.

```
#if __LP64__ || (TARGET_OS_EMBEDDED && !TARGET_OS_IPHONE) || TARGET_OS_WIN32 || NS_BUILD_32_LIKE_64
typedef long NSInteger;
typedef unsigned long NSUInteger;
#else
typedef int NSInteger;
typedef unsigned int NSUInteger;
#endif
```
