### PR TITLE
Do not attempt to archive all ivars of PFFile

### DIFF
--- a/PFFile+NSCoding.m
+++ b/PFFile+NSCoding.m
@@ -10,7 +10,7 @@
 #import <objc/runtime.h>
 
 #define kPFFileName @"_name"
-#define kPFFileIvars @"ivars"
+#define kPFFileURL @"_url"
 #define kPFFileData @"data"
 
 @implementation PFFile (NSCoding)
@@ -18,7 +18,7 @@
 - (void)encodeWithCoder:(NSCoder*)encoder
 {
 	[encoder encodeObject:self.name forKey:kPFFileName];
-	[encoder encodeObject:[self ivars] forKey:kPFFileIvars];
+    [encoder encodeObject:self.url forKey:kPFFileURL];
 	if (self.isDataAvailable) {
 		[encoder encodeObject:[self getData] forKey:kPFFileData];
 	}
@@ -27,35 +27,14 @@
 - (id)initWithCoder:(NSCoder*)aDecoder
 {
 	NSString* name = [aDecoder decodeObjectForKey:kPFFileName];
-	NSDictionary* ivars = [aDecoder decodeObjectForKey:kPFFileIvars];
+    NSString* url = [aDecoder decodeObjectForKey:kPFFileURL];
 	NSData* data = [aDecoder decodeObjectForKey:kPFFileData];
 	
 	self = [PFFile fileWithName:name data:data];
 	if (self) {
-		for (NSString* key in [ivars allKeys]) {
-			[self setValue:ivars[key] forKey:key];
-		}
+        [self setValue:url forKey:@"_url"];
 	}
 	return self;
-}
-
-- (NSDictionary *)ivars
-{
-    NSMutableDictionary* dict = [[NSMutableDictionary alloc] init];
-    unsigned int outCount;
-	
-    Ivar* ivars = class_copyIvarList([self class], &outCount);
-    for (int i = 0; i < outCount; i++){
-        Ivar ivar = ivars[i];
-        NSString* ivarNameString = [NSString stringWithUTF8String:ivar_getName(ivar)];
-        NSValue* value = [self valueForKey:ivarNameString];
-        if (value) {
-            [dict setValue:value forKey:ivarNameString];
-        }
-    }
-	
-    free(ivars);
-    return dict;
 }
 
 @end


### PR DESCRIPTION
Parse added a few ivars that cannot be archived which broke the category.
Instead, store the URL of the file explicitly.
