### PR TITLE
Switch to Parse 1.4

### DIFF
--- a/Parse+NSCoding.podspec
+++ b/Parse+NSCoding.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '6.0'
   s.source_files = '*.{h,m}'
   s.requires_arc = true
-  s.dependency 'Parse-iOS-SDK', '~> 1.2.18'
-  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"${PODS_ROOT}/Parse-iOS-SDK"' }
+  s.dependency 'Parse', '~> 1.4'
+  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"${PODS_ROOT}/Parse"' }
 end


### PR DESCRIPTION
Using Parse+NSCoding with 1.4 is impossible because of conflict between new Parse library and deprecated Parse-iOS-SDK. I know there are some issues with new Parse SDK and NSCoding+Parse. I have tested it on saving and restoring custom subclasses and it works. So PFACL and PFObject seem to be fine. Even if there are some issues with PFFile that I cannot confirm, it would be still easier to fix things when we have working pod.

Related to #19
