### PR TITLE
update spec to use the latest parse version.

### DIFF
--- a/Parse+NSCoding.podspec
+++ b/Parse+NSCoding.podspec
@@ -9,6 +9,5 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '6.0'
   s.source_files = '*.{h,m}'
   s.requires_arc = true
-  s.dependency 'Parse-iOS-SDK', '~> 1.2.18'
-  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"${PODS_ROOT}/Parse-iOS-SDK"' }
+  s.dependency "Parse", "~> 1.4.1"
 end


### PR DESCRIPTION
The Parse-iOS-SDK pod has been deprecated, it updates the spec dependency.
