### PR TITLE
Fork submodule Parse-NSCoding and fix PFFile decoding.

### DIFF
--- a/NSObject+Properties.m
+++ b/NSObject+Properties.m
@@ -22,7 +22,7 @@
 	NSDictionary* properties = [self properties];
 	for (NSString* key in properties) {
 		NSArray* attributes = properties[key][@"attributes"];
-		if ([attributes containsObject:@"D"]) {
+		if ([attributes containsObject:@"D"] && ![attributes containsObject:@"C"]) {
 			output[key] = properties[key];
 		}
 	}

--- a/PFFile+NSCoding.m
+++ b/PFFile+NSCoding.m
@@ -17,30 +17,24 @@
 
 - (void)encodeWithCoder:(NSCoder*)encoder
 {
-	[encoder encodeObject:self.name forKey:kPFFileName];
+    [encoder encodeObject:self.name forKey:kPFFileName];
     [encoder encodeObject:self.url forKey:kPFFileURL];
-	if (self.isDataAvailable) {
-		[encoder encodeObject:[self getData] forKey:kPFFileData];
-	}
+    if (self.isDataAvailable) {
+        [encoder encodeObject:[self getData] forKey:kPFFileData];
+    }
 }
 
 - (id)initWithCoder:(NSCoder*)aDecoder
 {
-	NSString* name = [aDecoder decodeObjectForKey:kPFFileName];
+    NSString* name = [aDecoder decodeObjectForKey:kPFFileName];
     NSString* url = [aDecoder decodeObjectForKey:kPFFileURL];
-	NSData* data = [aDecoder decodeObjectForKey:kPFFileData];
-	
-    if (data) {
-        self = [PFFile fileWithName:name data:data];
-    } else {
-        self = [PFFile new];
-        [self setValue:name forKey:kPFFileName];
-        [self setValue:url forKey:kPFFileURL];
+    NSData* data = [aDecoder decodeObjectForKey:kPFFileData];
+    
+    self = [PFFile fileWithName:name data:data];
+    if (self) {
+        [self setValue:url forKey:@"_url"];
     }
-	if (self) {
-        [self setValue:url forKey:kPFFileURL];
-	}
-	return self;
+    return self;
 }
 
 @end

--- a/PFFile+NSCoding.m
+++ b/PFFile+NSCoding.m
@@ -30,9 +30,15 @@
     NSString* url = [aDecoder decodeObjectForKey:kPFFileURL];
 	NSData* data = [aDecoder decodeObjectForKey:kPFFileData];
 	
-	self = [PFFile fileWithName:name data:data];
+    if (data) {
+        self = [PFFile fileWithName:name data:data];
+    } else {
+        self = [PFFile new];
+        [self setValue:name forKey:kPFFileName];
+        [self setValue:url forKey:kPFFileURL];
+    }
 	if (self) {
-        [self setValue:url forKey:@"_url"];
+        [self setValue:url forKey:kPFFileURL];
 	}
 	return self;
 }

--- a/PFFile+NSCoding.m
+++ b/PFFile+NSCoding.m
@@ -30,11 +30,14 @@
     NSString* url = [aDecoder decodeObjectForKey:kPFFileURL];
     NSData* data = [aDecoder decodeObjectForKey:kPFFileData];
     
-    self = [PFFile fileWithName:name data:data];
-    if (self) {
-        [self setValue:url forKey:@"_url"];
+    if (data) {
+        self = [PFFile fileWithName:name data:data];
+        if (self) {
+            [self setValue:url forKey:@"_url"];
+        }
+        return self;
     }
-    return self;
+    return nil;
 }
 
 @end

--- a/PFObject+NSCoding.m
+++ b/PFObject+NSCoding.m
@@ -71,7 +71,9 @@
 		//Deserialize all non-nil Parse properties
 		for (NSString* key in allKeys) {
             id obj = [aDecoder decodeObjectForKey:key];
-			self[key] = obj;
+            if (obj) {
+                self[key] = obj;
+            }
 		}
 		
 		//Deserialize all nil Parse properties with NSNull


### PR DESCRIPTION
Hello!

Please, have a look at my fix for PFFile decoding way.
There is could be a case when data is not yet downloaded and it is nil, but we still have to decode this PFFile with name and url only, so user can lazily download data later, otherwise we loose this PFFile from cache forever.

Thanks!
